### PR TITLE
fix for no method 'forEach'

### DIFF
--- a/desktop.blocks/grid/grid.js
+++ b/desktop.blocks/grid/grid.js
@@ -18,7 +18,7 @@ modules.define('i-bem__dom', ['jquery', 'BEMHTML', 'events__channels'], function
                     var channel = channels(CHANNEL_NAME);
                     var cellsClosed = 0;
 
-                    this.cells = DOM.blocks.cell;
+                    this.cells = this.findBlocksInside('cell');
 
                     channel.on(CHANNEL_EVENT_RESET, {}, function () {
                         this.resetGrid();


### PR DESCRIPTION
Uncaught TypeError: Object function () {
                return this.__constructor.apply(this, arguments);
            } has no method 'forEach'

разобрался после прочтения http://ru.bem.info/articles/bem-js-main-terms/ (Селекторы блоков)
